### PR TITLE
add static-library-networking configuration to also link openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ D language bindings to libgit2
 ==============================
 
 These are static bindings to the [libgit2](https://github.com/libgit2/libgit2) library. It directly exposes the C interface. For a higher level library with an idiomatic D interface, see [dlibgit](https://github.com/s-ludwig/dlibgit).
+
+Use the static-library configuration of this package to build and statically link against matching
+versions of libgit2.a and it's dependencies.
+Use the static-library-networking configuration if you want to use networking functionality of libgit2 (e.g. cloning repositories). It will link against the system's default openssl library.

--- a/dub.sdl
+++ b/dub.sdl
@@ -16,3 +16,11 @@ configuration "static-library" {
     lflags "-l$PACKAGE_DIR/lib/$PLATFORM-$ARCH/libgit2.a" "-l$PACKAGE_DIR/lib/$PLATFORM-$ARCH/libssh2.a"
     preBuildCommands `$PACKAGE_DIR/build_deps.sh '$PACKAGE_DIR/lib/$PLATFORM-$ARCH/'` platform="posix"
 }
+configuration "static-library-networking" {
+    sourceFiles "lib/$PLATFORM-$ARCH/libgit2.a" "lib/$PLATFORM-$ARCH/libssh2.a" "lib/$PLATFORM-$ARCH/libhttp_parser.o" platform="posix"
+    # Explicitly link so that the archive comes after the referencing sources on
+    # the link command line. Still keep sourceFiles so that dub relinks on change.
+    lflags "-l$PACKAGE_DIR/lib/$PLATFORM-$ARCH/libgit2.a" "-l$PACKAGE_DIR/lib/$PLATFORM-$ARCH/libssh2.a"
+    libs "openssl" platform="posix"
+    preBuildCommands `$PACKAGE_DIR/build_deps.sh '$PACKAGE_DIR/lib/$PLATFORM-$ARCH/'` platform="posix"
+}


### PR DESCRIPTION
- needed for networking functionality of libgit2 (TLS and libssh2 to be more specific)
- add separate config as not everyone might need networking, and
  linking against openssl makes it hard to distribute binaries