### PR TITLE
[FIX] git_treebuilder_create -> git_treebuilder_new

### DIFF
--- a/source/deimos/git2/commit.d
+++ b/source/deimos/git2/commit.d
@@ -87,7 +87,7 @@ int git_commit_create_buffer(
     const(char)* message,
     const(git_tree)* tree,
     size_t parent_count,
-    const(git_commit)* parents[]
+    const(git_commit)*[] parents
 );
 int git_commit_create_with_signature(
     git_oid *out_,

--- a/source/deimos/git2/tree.d
+++ b/source/deimos/git2/tree.d
@@ -41,8 +41,8 @@ int git_tree_entry_to_object(
 	git_object **object_out,
 	git_repository *repo,
 	const(git_tree_entry)* entry);
-int git_treebuilder_create(
-	git_treebuilder **out_, const(git_tree)* source);
+int git_treebuilder_new(
+    git_treebuilder **out_, git_repository *repo, const(git_tree) *source);
 void git_treebuilder_clear(git_treebuilder *bld);
 uint git_treebuilder_entrycount(git_treebuilder *bld);
 void git_treebuilder_free(git_treebuilder *bld);


### PR DESCRIPTION
Plus minor syntax fix in source/deimos/git2/commit.d

Links:
- [git_treebuilder_new](https://libgit2.org/libgit2/#v0.25.1/group/treebuilder/git_treebuilder_new)
- [git_treebuilder_create](https://libgit2.org/libgit2/#v0.20.0/group/treebuilder/git_treebuilder_create)